### PR TITLE
feat: VK API client — typed wrapper for /api/remote/*

### DIFF
--- a/src/vk/client.ts
+++ b/src/vk/client.ts
@@ -1,49 +1,154 @@
-export interface VKCard {
+import { readFileSync, existsSync } from 'fs'
+
+export interface VKOrg {
   id: string
-  title: string
-  description?: string
-  status: string
-  projectId: string
+  name: string
 }
 
 export interface VKProject {
   id: string
   name: string
-  cards: VKCard[]
 }
 
+export interface VKStatus {
+  id: string
+  name: string
+  project_id: string
+}
+
+export interface VKIssue {
+  id: string
+  simple_id: string
+  title: string
+  description: string | null
+  status_id: string
+  priority: string
+  sort_order: number
+  project_id: string
+}
+
+export interface VKStatusMap {
+  backlog: string
+  todo: string
+  in_progress: string
+  in_review: string
+  done: string
+  cancelled: string
+}
+
+const VK_PORT_FILE = '/var/folders/b5/d07g827s1l9fw40nk5l421xm0000gn/T/vibe-kanban/vibe-kanban.port'
+
 export class VKClient {
-  private baseUrl: string
+  private port: number
 
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl
+  constructor(fallbackPort = 3333) {
+    this.port = this.detectPort(fallbackPort)
   }
 
-  async getProjects(): Promise<VKProject[]> {
-    throw new Error('not implemented')
+  private detectPort(fallback: number): number {
+    try {
+      if (existsSync(VK_PORT_FILE)) {
+        const data = JSON.parse(readFileSync(VK_PORT_FILE, 'utf-8'))
+        return data.main_port ?? fallback
+      }
+    } catch {}
+    return fallback
   }
 
-  async getProject(_id: string): Promise<VKProject> {
-    throw new Error('not implemented')
+  private url(path: string): string {
+    return `http://localhost:${this.port}/api${path}`
   }
 
-  async getCards(_projectId: string): Promise<VKCard[]> {
-    throw new Error('not implemented')
+  private async get<T>(path: string): Promise<T> {
+    const res = await fetch(this.url(path))
+    if (!res.ok) throw new Error(`VK GET ${path} → ${res.status}`)
+    return res.json() as Promise<T>
   }
 
-  async createCard(_projectId: string, _title: string, _description?: string): Promise<VKCard> {
-    throw new Error('not implemented')
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(this.url(path), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+    if (!res.ok) throw new Error(`VK POST ${path} → ${res.status}`)
+    return res.json() as Promise<T>
   }
 
-  async updateCard(_cardId: string, _patch: Partial<VKCard>): Promise<VKCard> {
-    throw new Error('not implemented')
+  private async patch<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(this.url(path), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
+    if (!res.ok) throw new Error(`VK PATCH ${path} → ${res.status}`)
+    return res.json() as Promise<T>
   }
 
-  async healthCheck(): Promise<boolean> {
-    throw new Error('not implemented')
+  async getOrganizations(): Promise<VKOrg[]> {
+    const r = await this.get<{ data: { organizations: VKOrg[] } }>('/organizations')
+    return r.data.organizations
   }
 
-  getBaseUrl(): string {
-    return this.baseUrl
+  async listProjects(orgId: string): Promise<VKProject[]> {
+    const r = await this.get<{ data: { projects: VKProject[] } }>(`/remote/projects?organization_id=${orgId}`)
+    return r.data.projects
+  }
+
+  async listIssues(projectId: string): Promise<VKIssue[]> {
+    const r = await this.get<{ data: { issues: VKIssue[] } }>(`/remote/issues?project_id=${projectId}`)
+    return r.data.issues
+  }
+
+  async getStatuses(projectId: string): Promise<VKStatusMap> {
+    const r = await this.get<{ data: { project_statuses: VKStatus[] } }>(`/remote/project-statuses?project_id=${projectId}`)
+    const map: Record<string, string> = {}
+    for (const s of r.data.project_statuses) {
+      map[s.name.toLowerCase().replace(/ /g, '_')] = s.id
+    }
+    return {
+      backlog: map['backlog'] ?? '',
+      todo: map['to_do'] ?? '',
+      in_progress: map['in_progress'] ?? '',
+      in_review: map['in_review'] ?? '',
+      done: map['done'] ?? '',
+      cancelled: map['cancelled'] ?? ''
+    }
+  }
+
+  async createIssue(params: {
+    project_id: string
+    status_id: string
+    title: string
+    description?: string
+    priority?: string
+    sort_order?: number
+  }): Promise<VKIssue> {
+    const r = await this.post<{ data: { data: VKIssue } }>('/remote/issues', {
+      ...params,
+      priority: params.priority ?? 'medium',
+      sort_order: params.sort_order ?? 1.0,
+      extension_metadata: {}
+    })
+    return r.data.data
+  }
+
+  async updateIssueStatus(issueId: string, statusId: string): Promise<VKIssue> {
+    const r = await this.patch<{ data: { data: VKIssue } }>(`/remote/issues/${issueId}`, { status_id: statusId })
+    return r.data.data
+  }
+
+  async findIssueByGHNumber(projectId: string, ghNumber: number): Promise<VKIssue | null> {
+    const issues = await this.listIssues(projectId)
+    return issues.find(i => i.title.startsWith(`#${ghNumber} `)) ?? null
+  }
+
+  async isConnected(): Promise<boolean> {
+    try {
+      await this.getOrganizations()
+      return true
+    } catch {
+      return false
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Replaces stub `VKClient` with full typed implementation of the Vibe Kanban HTTP API
- Auto-detects VK server port from the platform temp file (`vibe-kanban.port`), falls back to `vk_port` config or default 3333
- Typed interfaces: `VKOrg`, `VKProject`, `VKStatus`, `VKIssue`, `VKStatusMap`
- Methods: `getOrganizations`, `listProjects`, `listIssues`, `getStatuses`, `createIssue`, `updateIssueStatus`, `findIssueByGHNumber`, `isConnected`

Closes #3

## Test plan

- [ ] `npm run typecheck` passes (0 errors) ✅
- [ ] Port auto-detection reads from `/var/folders/.../vibe-kanban.port` when present
- [ ] Falls back to `fallbackPort` (default 3333) when file absent
- [ ] `createIssue` defaults to priority `medium` and `sort_order 1.0` when omitted
- [ ] `findIssueByGHNumber` matches on `#N ` title prefix convention
- [ ] `getStatuses` normalises status names to snake_case keys in `VKStatusMap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)