### PR TITLE
feat: Session Registry — POST/PATCH/GET /sessions

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,31 +1,194 @@
+import { randomUUID } from 'crypto'
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { VKClient, type VKStatusMap } from '../vk/client.js'
+import { CardMatcher } from '../matcher/index.js'
+import { loadConfig } from '../config.js'
+
 export interface Session {
   id: string
-  agentId: string
-  status: 'active' | 'idle' | 'closed'
-  createdAt: Date
-  updatedAt: Date
+  runtime: 'claude_code' | 'gemini' | 'zora' | 'unknown'
+  project_path: string
+  branch: string
+  worktree_path?: string
+  pid?: number
+  vk_card_id: string
+  vk_card_simple_id: string
+  vk_project_id: string
+  vk_status_ids: VKStatusMap
+  status: 'in_progress' | 'in_review' | 'done' | 'blocked'
+  started_at: string
+  updated_at: string
+}
+
+export interface SessionInput {
+  runtime: Session['runtime']
+  project_path: string
+  branch: string
+  worktree_path?: string
+  pid?: number
+}
+
+interface ActiveSessionFile {
+  session_id: string
+  vk_card_id: string
+  vk_card_simple_id: string
+  vk_project_id: string
+  vk_status_ids: VKStatusMap
+}
+
+function activeDir(): string {
+  return join(homedir(), '.vk-bridge', 'active')
+}
+
+function activeFilePath(pid: number): string {
+  return join(activeDir(), `${pid}.json`)
+}
+
+function writeActiveFile(session: Session): void {
+  if (session.pid == null) return
+  const dir = activeDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  const data: ActiveSessionFile = {
+    session_id: session.id,
+    vk_card_id: session.vk_card_id,
+    vk_card_simple_id: session.vk_card_simple_id,
+    vk_project_id: session.vk_project_id,
+    vk_status_ids: session.vk_status_ids
+  }
+  writeFileSync(activeFilePath(session.pid), JSON.stringify(data, null, 2))
+}
+
+function deleteActiveFile(pid: number): void {
+  const path = activeFilePath(pid)
+  try {
+    if (existsSync(path)) unlinkSync(path)
+  } catch {
+    // ignore
+  }
+}
+
+const STATUS_TO_VK_KEY: Record<string, keyof VKStatusMap | null> = {
+  in_progress: 'in_progress',
+  in_review: 'in_review',
+  done: 'done',
+  blocked: null
 }
 
 export class SessionRegistry {
   private sessions: Map<string, Session> = new Map()
 
-  register(_agentId: string): Session {
-    throw new Error('not implemented')
+  async register(input: SessionInput): Promise<Session> {
+    const now = new Date().toISOString()
+    const id = randomUUID()
+
+    let vk_card_id = ''
+    let vk_card_simple_id = 'UNKNOWN'
+    let vk_project_id = ''
+    let vk_status_ids: VKStatusMap = {
+      backlog: '',
+      todo: '',
+      in_progress: '',
+      in_review: '',
+      done: '',
+      cancelled: ''
+    }
+
+    try {
+      const config = loadConfig()
+      const client = new VKClient(config.vk_port)
+      const matcher = new CardMatcher(client, config)
+
+      const result = await matcher.matchOrCreate({
+        project_path: input.project_path,
+        branch: input.branch,
+        worktree_path: input.worktree_path
+      })
+
+      const card = result.card
+      vk_project_id = card.project_id
+      vk_status_ids = await client.getStatuses(vk_project_id)
+      vk_card_id = card.id
+      vk_card_simple_id = card.simple_id
+
+      // Move card to in_progress
+      if (vk_status_ids.in_progress) {
+        await client.updateIssueStatus(card.id, vk_status_ids.in_progress)
+      }
+    } catch (err) {
+      console.error('[vk-bridge] VK unavailable during register:', (err as Error).message)
+    }
+
+    const session: Session = {
+      id,
+      runtime: input.runtime,
+      project_path: input.project_path,
+      branch: input.branch,
+      worktree_path: input.worktree_path,
+      pid: input.pid,
+      vk_card_id,
+      vk_card_simple_id,
+      vk_project_id,
+      vk_status_ids,
+      status: 'in_progress',
+      started_at: now,
+      updated_at: now
+    }
+
+    this.sessions.set(id, session)
+    writeActiveFile(session)
+
+    return session
   }
 
-  get(_id: string): Session | undefined {
-    throw new Error('not implemented')
+  async update(id: string, patch: { status: Session['status'] }): Promise<Session> {
+    const session = this.sessions.get(id)
+    if (!session) {
+      throw new Error(`Session not found: ${id}`)
+    }
+
+    const updated: Session = {
+      ...session,
+      status: patch.status,
+      updated_at: new Date().toISOString()
+    }
+
+    this.sessions.set(id, updated)
+
+    // Move VK card if applicable
+    const vkKey = STATUS_TO_VK_KEY[patch.status]
+    if (vkKey !== null && updated.vk_card_id) {
+      const statusId = updated.vk_status_ids[vkKey]
+      if (statusId) {
+        try {
+          const config = loadConfig()
+          const client = new VKClient(config.vk_port)
+          await client.updateIssueStatus(updated.vk_card_id, statusId)
+        } catch (err) {
+          console.error('[vk-bridge] VK unavailable during update:', (err as Error).message)
+        }
+      }
+    }
+
+    return updated
   }
 
-  update(_id: string, _patch: Partial<Session>): Session {
-    throw new Error('not implemented')
+  get(id: string): Session | undefined {
+    return this.sessions.get(id)
   }
 
   list(): Session[] {
     return Array.from(this.sessions.values())
   }
 
-  close(_id: string): void {
-    throw new Error('not implemented')
+  async close(id: string): Promise<void> {
+    await this.update(id, { status: 'done' })
+    const session = this.sessions.get(id)
+    if (session?.pid != null) {
+      deleteActiveFile(session.pid)
+    }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,26 +1,75 @@
 import Fastify from 'fastify'
+import { SessionRegistry } from './registry/index.js'
+import { VKClient } from './vk/client.js'
+import { loadConfig } from './config.js'
 
 const app = Fastify({ logger: true })
+const registry = new SessionRegistry()
+
+interface SessionBody {
+  runtime: 'claude_code' | 'gemini' | 'zora' | 'unknown'
+  project_path: string
+  branch: string
+  worktree_path?: string
+  pid?: number
+}
+
+interface UpdateBody {
+  status: 'in_progress' | 'in_review' | 'done' | 'blocked'
+}
 
 app.get('/health', async () => {
+  const config = loadConfig()
+  const client = new VKClient(config.vk_port)
+  const vk_connected = await client.isConnected()
+  const sessions_active = registry.list().filter(s => s.status === 'in_progress').length
+
   return {
     ok: true,
     version: '0.1.0',
-    vk_connected: false,
-    sessions_active: 0,
+    vk_connected,
+    sessions_active,
   }
 })
 
-app.post('/sessions', async (_request, reply) => {
-  return reply.status(501).send({ error: 'not implemented' })
+app.post<{ Body: SessionBody }>('/sessions', async (request, reply) => {
+  const body = request.body
+  if (!body?.runtime || !body?.project_path || !body?.branch) {
+    return reply.status(400).send({ error: 'Missing required fields: runtime, project_path, branch' })
+  }
+
+  const session = await registry.register({
+    runtime: body.runtime,
+    project_path: body.project_path,
+    branch: body.branch,
+    worktree_path: body.worktree_path,
+    pid: body.pid
+  })
+
+  return reply.status(200).send({
+    session_id: session.id,
+    vk_card_id: session.vk_card_id,
+    vk_card_simple_id: session.vk_card_simple_id,
+    vk_project_id: session.vk_project_id,
+    vk_status_ids: session.vk_status_ids
+  })
 })
 
-app.patch('/sessions/:id', async (_request, reply) => {
-  return reply.status(501).send({ error: 'not implemented' })
+app.patch<{ Params: { id: string }; Body: UpdateBody }>('/sessions/:id', async (request, reply) => {
+  const { id } = request.params
+  const body = request.body
+
+  const existing = registry.get(id)
+  if (!existing) {
+    return reply.status(404).send({ error: `Session not found: ${id}` })
+  }
+
+  const updated = await registry.update(id, { status: body.status })
+  return reply.status(200).send(updated)
 })
 
 app.get('/sessions', async () => {
-  return { sessions: [] }
+  return { sessions: registry.list() }
 })
 
 const start = async () => {


### PR DESCRIPTION
Closes #5

## Summary

- Implements full `SessionRegistry` class in `src/registry/index.ts` with `register()`, `update()`, `get()`, `list()`, and `close()` methods
- Integrates `CardMatcher` + `VKClient` on `register()` to match/create a VK card and move it to `in_progress`; gracefully degrades if VK is unreachable
- Writes `~/.vk-bridge/active/{pid}.json` on register (when `pid` provided) and deletes it on `close()`
- Replaces stub routes in `src/server.ts` with real implementations: `POST /sessions`, `PATCH /sessions/:id`, `GET /sessions`, and updated `GET /health` with live `vk_connected` and `sessions_active` counts

## Test plan

- [ ] `npm run typecheck` passes with 0 errors
- [ ] `POST /sessions` with valid body returns `session_id`, `vk_card_id`, `vk_card_simple_id`, `vk_project_id`, `vk_status_ids`
- [ ] `POST /sessions` missing required fields returns 400
- [ ] `PATCH /sessions/:id` with valid status updates session and moves VK card
- [ ] `PATCH /sessions/:id` with unknown id returns 404
- [ ] `GET /sessions` returns `{ sessions: [...] }`
- [ ] `GET /health` reflects live `vk_connected` and correct `sessions_active` count
- [ ] `~/.vk-bridge/active/{pid}.json` written on register and deleted on close
- [ ] VK unreachable: session still created with `vk_card_id = ''` and `vk_card_simple_id = 'UNKNOWN'`