### PR TITLE
feat: Claude Code hooks — auto-register every claude session

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ VK is designed for humans to create tasks then start agents from the UI. Most ac
 - **All `~/Dev` projects** — not just ones with GitHub issues
 - **Terminal CLI** (`vkb`) — create/manage cards without the UI
 
+## Quick Start
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Install Claude Code hooks (auto-registers every claude session)
+npm run install-hooks
+
+# 3. Start vk-bridge
+npm run dev
+```
+
+After installing hooks, every `claude` session auto-creates a VK card and moves it through columns as you work.
+
 ## Docs
 
 - [`SPEC.md`](./SPEC.md) — full architecture and implementation spec

--- a/hooks/claude-context.sh
+++ b/hooks/claude-context.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Called by Claude Code UserPromptSubmit hook
+# Outputs VK card context that gets injected into system prompt
+
+PID=$$
+ACTIVE_FILE=~/.vk-bridge/active/${PID}.json
+
+if [ ! -f "$ACTIVE_FILE" ]; then
+  exit 0
+fi
+
+SESSION_ID=$(python3 -c "import sys,json; d=json.load(open('$ACTIVE_FILE')); print(d.get('session_id',''))" 2>/dev/null || echo "")
+CARD_SIMPLE=$(python3 -c "import sys,json; d=json.load(open('$ACTIVE_FILE')); print(d.get('vk_card_simple_id',''))" 2>/dev/null || echo "")
+
+if [ -n "$SESSION_ID" ] && [ -n "$CARD_SIMPLE" ]; then
+  # Fetch current card title from vk-bridge
+  CARD_INFO=$(curl -sf "http://localhost:3334/sessions/$SESSION_ID" 2>/dev/null || echo "")
+  if [ -n "$CARD_INFO" ]; then
+    CARD_STATUS=$(echo "$CARD_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || echo "")
+    echo "[VK] Card $CARD_SIMPLE — $CARD_STATUS | Move: vkb review | vkb done"
+  fi
+fi

--- a/hooks/claude-start.sh
+++ b/hooks/claude-start.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Called by Claude Code SessionStart hook
+# Env vars provided by Claude Code: CLAUDE_PROJECT_DIR, CLAUDE_SESSION_ID
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+PID=$$
+
+# Register with vk-bridge
+RESPONSE=$(curl -sf -X POST http://localhost:3334/sessions \
+  -H "Content-Type: application/json" \
+  -d "{\"runtime\":\"claude_code\",\"project_path\":\"$PROJECT_DIR\",\"branch\":\"$BRANCH\",\"pid\":$PID}" \
+  2>/dev/null) || {
+  # vk-bridge not running — silently exit (non-blocking)
+  exit 0
+}
+
+SESSION_ID=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['session_id'])" 2>/dev/null || echo "")
+CARD_SIMPLE=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['vk_card_simple_id'])" 2>/dev/null || echo "")
+
+if [ -n "$SESSION_ID" ]; then
+  mkdir -p ~/.vk-bridge/active
+  echo "$RESPONSE" > ~/.vk-bridge/active/${PID}.json
+  # Output context injection for Claude — this goes into the system prompt
+  echo "[VK] Registered as $CARD_SIMPLE (session $SESSION_ID)"
+  echo "[VK] Move with: vkb review | vkb done"
+fi

--- a/hooks/claude-stop.sh
+++ b/hooks/claude-stop.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Called by Claude Code Stop hook
+
+set -euo pipefail
+
+PID=$$
+ACTIVE_FILE=~/.vk-bridge/active/${PID}.json
+
+if [ ! -f "$ACTIVE_FILE" ]; then
+  exit 0
+fi
+
+SESSION_ID=$(python3 -c "import sys,json; d=json.load(open('$ACTIVE_FILE')); print(d['session_id'])" 2>/dev/null || echo "")
+
+if [ -n "$SESSION_ID" ]; then
+  # Determine status from git state
+  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+  BRANCH=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+  # Check if branch has upstream
+  HAS_UPSTREAM=$(git -C "$PROJECT_DIR" rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "")
+
+  if [ -n "$HAS_UPSTREAM" ]; then
+    STATUS="in_review"
+  else
+    STATUS="in_progress"
+  fi
+
+  curl -sf -X PATCH "http://localhost:3334/sessions/$SESSION_ID" \
+    -H "Content-Type: application/json" \
+    -d "{\"status\":\"$STATUS\"}" \
+    > /dev/null 2>&1 || true
+fi
+
+rm -f "$ACTIVE_FILE"

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Install vk-bridge hooks into ~/.claude/settings.json
+
+set -euo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETTINGS_FILE=~/.claude/settings.json
+
+echo "Installing vk-bridge Claude Code hooks..."
+echo "  Hook scripts: $HOOKS_DIR"
+echo "  Settings file: $SETTINGS_FILE"
+
+# Ensure settings file exists
+if [ ! -f "$SETTINGS_FILE" ]; then
+  echo "{}" > "$SETTINGS_FILE"
+fi
+
+# Use python3 to safely merge hooks into settings.json
+python3 << PYEOF
+import json, os
+
+settings_path = os.path.expanduser("$SETTINGS_FILE")
+hooks_dir = "$HOOKS_DIR"
+
+with open(settings_path) as f:
+    settings = json.load(f)
+
+new_hooks = {
+    "SessionStart": [{
+        "matcher": ".*",
+        "hooks": [{"type": "command", "command": f"{hooks_dir}/claude-start.sh"}]
+    }],
+    "Stop": [{
+        "matcher": ".*",
+        "hooks": [{"type": "command", "command": f"{hooks_dir}/claude-stop.sh"}]
+    }],
+    "UserPromptSubmit": [{
+        "matcher": ".*",
+        "hooks": [{"type": "command", "command": f"{hooks_dir}/claude-context.sh"}]
+    }]
+}
+
+# Merge: add vk-bridge hooks without removing existing ones
+existing = settings.get("hooks", {})
+for event, hook_list in new_hooks.items():
+    if event not in existing:
+        existing[event] = hook_list
+    else:
+        # Check if vk-bridge hook already present
+        vkb_commands = {h["hooks"][0]["command"] for h in hook_list}
+        already = any(
+            h["hooks"][0]["command"] in vkb_commands
+            for h in existing[event]
+            if h.get("hooks")
+        )
+        if not already:
+            existing[event].extend(hook_list)
+
+settings["hooks"] = existing
+
+with open(settings_path, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+
+print("✓ Hooks installed into", settings_path)
+PYEOF

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "install-hooks": "bash hooks/install.sh"
   },
   "dependencies": {
     "fastify": "^5.0.0"

--- a/src/server.ts
+++ b/src/server.ts
@@ -72,6 +72,14 @@ app.get('/sessions', async () => {
   return { sessions: registry.list() }
 })
 
+app.get<{ Params: { id: string } }>('/sessions/:id', async (request, reply) => {
+  const session = registry.get(request.params.id)
+  if (!session) {
+    return reply.status(404).send({ error: `Session not found: ${request.params.id}` })
+  }
+  return session
+})
+
 const start = async () => {
   try {
     await app.listen({ port: 3334, host: '0.0.0.0' })


### PR DESCRIPTION
## Summary

- Adds three shell hook scripts (`hooks/claude-start.sh`, `claude-stop.sh`, `claude-context.sh`) that auto-register/deregister Claude sessions with vk-bridge via the REST API
- Adds `hooks/install.sh` that safely merges hook entries into `~/.claude/settings.json` without clobbering existing hooks
- Adds `GET /sessions/:id` route to `src/server.ts` so `claude-context.sh` can fetch live card status
- Adds `npm run install-hooks` script and Quick Start section to README

## Test plan

- [ ] Run `npm run install-hooks` — verify `~/.claude/settings.json` gains `SessionStart`, `Stop`, and `UserPromptSubmit` entries pointing at the hook scripts
- [ ] Run `npm run install-hooks` a second time — verify no duplicate entries are added
- [ ] Start `npm run dev`, then call `curl http://localhost:3334/sessions/<id>` — verify 200 or 404 response
- [ ] `npm run typecheck` passes with 0 errors
- [ ] All four hook scripts are executable (`ls -la hooks/`)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)