### PR TITLE
feat: GitHub → VK webhook handler + deferred event queue

### DIFF
--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -1,0 +1,230 @@
+import { createHmac } from 'crypto'
+import { GitHubClient } from './client.js'
+import { VKClient, type VKStatusMap } from '../vk/client.js'
+import { loadConfig, getProjectConfig } from '../config.js'
+import type { SessionRegistry } from '../registry/index.js'
+
+// ─── Payload shapes ────────────────────────────────────────────────────────
+
+interface GHIssueMini {
+  number: number
+  title: string
+  body: string | null
+  html_url: string
+  state: 'open' | 'closed'
+  state_reason: string | null
+}
+
+interface GHPRMini {
+  number: number
+  title: string
+  body: string | null
+  html_url: string
+  merged: boolean
+  head: { ref: string }
+}
+
+interface GHRepoMini {
+  full_name: string
+}
+
+interface IssuesPayload {
+  action: string
+  issue: GHIssueMini
+  repository: GHRepoMini
+}
+
+interface PRPayload {
+  action: string
+  pull_request: GHPRMini
+  repository: GHRepoMini
+}
+
+type WebhookPayload = IssuesPayload | PRPayload | Record<string, unknown>
+
+// ─── HMAC verification ─────────────────────────────────────────────────────
+
+export function verifySignature(body: string, signature: string, secret: string): boolean {
+  if (!signature.startsWith('sha256=')) return false
+  const expected = 'sha256=' + createHmac('sha256', secret).update(body).digest('hex')
+  // Constant-time comparison
+  if (expected.length !== signature.length) return false
+  let diff = 0
+  for (let i = 0; i < expected.length; i++) {
+    diff |= expected.charCodeAt(i) ^ signature.charCodeAt(i)
+  }
+  return diff === 0
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/** Find project config matching the incoming repo (e.g. 'ryaker/vk-bridge') */
+function findProjectForRepo(repoFullName: string): {
+  projectPath: string
+  vkProjectId: string
+  ghClient: GitHubClient
+} | null {
+  const config = loadConfig()
+  for (const [projectPath, proj] of Object.entries(config.projects)) {
+    if (proj.github_repo === repoFullName && proj.vk_project_id && proj.github_token) {
+      return {
+        projectPath,
+        vkProjectId: proj.vk_project_id,
+        ghClient: new GitHubClient(repoFullName, proj.github_token)
+      }
+    }
+  }
+  return null
+}
+
+/** Get VK status map for a project, cached per call */
+async function getStatuses(client: VKClient, projectId: string): Promise<VKStatusMap> {
+  return client.getStatuses(projectId)
+}
+
+/** Move a VK card to a given status key, if the card isn't agent-owned */
+async function moveCard(
+  vkCardId: string,
+  statusKey: keyof VKStatusMap,
+  statuses: VKStatusMap,
+  registry: SessionRegistry,
+  deferPayload?: { eventType: string; payload: unknown }
+): Promise<'moved' | 'deferred' | 'noop'> {
+  const statusId = statuses[statusKey]
+  if (!statusId) return 'noop'
+
+  if (registry.isAgentOwned(vkCardId)) {
+    if (deferPayload) {
+      registry.deferEvent(vkCardId, deferPayload.eventType, deferPayload.payload)
+    }
+    return 'deferred'
+  }
+
+  const config = loadConfig()
+  const client = new VKClient(config.vk_port)
+  await client.updateIssueStatus(vkCardId, statusId)
+  return 'moved'
+}
+
+// ─── Event handlers ────────────────────────────────────────────────────────
+
+async function handleIssuesEvent(
+  payload: IssuesPayload,
+  registry: SessionRegistry
+): Promise<string> {
+  const { action, issue, repository } = payload
+  const match = findProjectForRepo(repository.full_name)
+  if (!match) return `no project configured for ${repository.full_name}`
+
+  const config = loadConfig()
+  const vkClient = new VKClient(config.vk_port)
+  const statuses = await getStatuses(vkClient, match.vkProjectId)
+
+  // Find existing VK card for this issue
+  const vkCard = await vkClient.findIssueByGHNumber(match.vkProjectId, issue.number)
+
+  if (action === 'opened') {
+    if (vkCard) return `card already exists: ${vkCard.simple_id}`
+    // Create new card in Backlog
+    await vkClient.createIssue({
+      project_id: match.vkProjectId,
+      status_id: statuses.backlog,
+      title: `#${issue.number} ${issue.title}`,
+      description: issue.body ?? undefined,
+      priority: 'medium'
+    })
+    return `created backlog card for #${issue.number}`
+  }
+
+  if (!vkCard) return `no VK card found for #${issue.number}`
+
+  if (action === 'assigned') {
+    const result = await moveCard(vkCard.id, 'todo', statuses, registry, {
+      eventType: `issues.${action}`,
+      payload
+    })
+    return `issues.assigned → todo: ${result}`
+  }
+
+  if (action === 'closed') {
+    // closed with state_reason 'completed' or 'merged' → Done; otherwise → Cancelled
+    const reason = issue.state_reason
+    const targetKey: keyof VKStatusMap = reason === 'not_planned' ? 'cancelled' : 'done'
+    const result = await moveCard(vkCard.id, targetKey, statuses, registry, {
+      eventType: `issues.${action}`,
+      payload
+    })
+    return `issues.closed → ${targetKey}: ${result}`
+  }
+
+  if (action === 'reopened') {
+    const result = await moveCard(vkCard.id, 'todo', statuses, registry, {
+      eventType: `issues.${action}`,
+      payload
+    })
+    return `issues.reopened → todo: ${result}`
+  }
+
+  return `unhandled issues action: ${action}`
+}
+
+async function handlePREvent(
+  payload: PRPayload,
+  registry: SessionRegistry
+): Promise<string> {
+  const { action, pull_request: pr, repository } = payload
+  const match = findProjectForRepo(repository.full_name)
+  if (!match) return `no project configured for ${repository.full_name}`
+
+  // Only care about opened and closed+merged
+  if (action !== 'opened' && !(action === 'closed' && pr.merged)) {
+    return `ignored pull_request.${action}`
+  }
+
+  // Find linked issue from PR body
+  const issueNumber = GitHubClient.extractLinkedIssue(pr.body)
+  if (!issueNumber) return `no linked issue found in PR #${pr.number}`
+
+  const config = loadConfig()
+  const vkClient = new VKClient(config.vk_port)
+  const statuses = await getStatuses(vkClient, match.vkProjectId)
+  const vkCard = await vkClient.findIssueByGHNumber(match.vkProjectId, issueNumber)
+  if (!vkCard) return `no VK card found for #${issueNumber}`
+
+  if (action === 'opened') {
+    const result = await moveCard(vkCard.id, 'in_review', statuses, registry, {
+      eventType: 'pull_request.opened',
+      payload
+    })
+    return `pull_request.opened → in_review: ${result}`
+  }
+
+  // closed + merged
+  const result = await moveCard(vkCard.id, 'done', statuses, registry, {
+    eventType: 'pull_request.merged',
+    payload
+  })
+  return `pull_request.merged → done: ${result}`
+}
+
+// ─── Main dispatcher ────────────────────────────────────────────────────────
+
+export async function handleWebhook(
+  eventType: string,
+  payload: WebhookPayload,
+  registry: SessionRegistry
+): Promise<string> {
+  try {
+    if (eventType === 'issues') {
+      return await handleIssuesEvent(payload as IssuesPayload, registry)
+    }
+    if (eventType === 'pull_request') {
+      return await handlePREvent(payload as PRPayload, registry)
+    }
+    return `ignored event: ${eventType}`
+  } catch (err) {
+    const msg = (err as Error).message
+    console.error(`[vk-bridge] webhook error (${eventType}):`, msg)
+    throw err
+  }
+}

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -78,8 +78,15 @@ const STATUS_TO_VK_KEY: Record<string, keyof VKStatusMap | null> = {
   blocked: null
 }
 
+interface DeferredEvent {
+  eventType: string
+  payload: unknown
+  queued_at: string
+}
+
 export class SessionRegistry {
   private sessions: Map<string, Session> = new Map()
+  private deferredEvents: Map<string, DeferredEvent[]> = new Map()
 
   async register(input: SessionInput): Promise<Session> {
     const now = new Date().toISOString()
@@ -190,5 +197,32 @@ export class SessionRegistry {
     if (session?.pid != null) {
       deleteActiveFile(session.pid)
     }
+  }
+
+  /** Returns true if any active session owns this VK card and is in progress/in_review */
+  isAgentOwned(vkCardId: string): boolean {
+    for (const session of this.sessions.values()) {
+      if (
+        session.vk_card_id === vkCardId &&
+        (session.status === 'in_progress' || session.status === 'in_review')
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
+  /** Queue a GitHub event for a card currently owned by an agent */
+  deferEvent(vkCardId: string, eventType: string, payload: unknown): void {
+    const queue = this.deferredEvents.get(vkCardId) ?? []
+    queue.push({ eventType, payload, queued_at: new Date().toISOString() })
+    this.deferredEvents.set(vkCardId, queue)
+  }
+
+  /** Drain and return all deferred events for a card, clearing the queue */
+  releaseDeferredEvents(vkCardId: string): DeferredEvent[] {
+    const events = this.deferredEvents.get(vkCardId) ?? []
+    this.deferredEvents.delete(vkCardId)
+    return events
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import Fastify from 'fastify'
 import { SessionRegistry } from './registry/index.js'
 import { VKClient } from './vk/client.js'
 import { loadConfig } from './config.js'
+import { verifySignature, handleWebhook } from './github/webhook.js'
 
 const app = Fastify({ logger: true })
 const registry = new SessionRegistry()
@@ -78,6 +79,47 @@ app.get<{ Params: { id: string } }>('/sessions/:id', async (request, reply) => {
     return reply.status(404).send({ error: `Session not found: ${request.params.id}` })
   }
   return session
+})
+
+// Webhook endpoint — Fastify needs raw body for HMAC verification
+app.addContentTypeParser('application/json', { parseAs: 'string' }, (req, body, done) => {
+  try {
+    done(null, JSON.parse(body as string))
+  } catch (err) {
+    done(err as Error, undefined)
+  }
+})
+
+app.post<{ Body: unknown }>('/github/webhook', {
+  config: { rawBody: true }
+}, async (request, reply) => {
+  const eventType = request.headers['x-github-event'] as string | undefined
+  const signature = request.headers['x-hub-signature-256'] as string | undefined
+
+  if (!eventType) {
+    return reply.status(400).send({ error: 'Missing X-GitHub-Event header' })
+  }
+
+  // Verify HMAC signature if secret is configured for this repo
+  if (signature) {
+    const rawBody = JSON.stringify(request.body)
+    const config = loadConfig()
+    // Find the matching project by inspecting the payload's repository
+    const repoFullName = (request.body as Record<string, { full_name?: string }>)?.repository?.full_name
+    if (repoFullName) {
+      // Find project config for this repo
+      const projectEntry = Object.entries(config.projects).find(
+        ([, proj]) => proj.github_repo === repoFullName
+      )
+      const secret = projectEntry?.[1]?.github_webhook_secret
+      if (secret && !verifySignature(rawBody, signature, secret)) {
+        return reply.status(401).send({ error: 'Invalid webhook signature' })
+      }
+    }
+  }
+
+  const result = await handleWebhook(eventType, request.body as Record<string, unknown>, registry)
+  return reply.status(200).send({ ok: true, result })
 })
 
 const start = async () => {


### PR DESCRIPTION
## Summary
- `POST /github/webhook` with HMAC-SHA256 signature verification
- Routes GitHub events to VK card moves: issues (opened/assigned/closed/reopened) and pull_request (opened/merged)
- Agent sovereignty: cards owned by active sessions (in_progress or in_review) have GitHub events deferred, not applied
- Adds `isAgentOwned()`, `deferEvent()`, `releaseDeferredEvents()` to `SessionRegistry`

## Event map

| GitHub event | VK action |
|---|---|
| `issues.opened` | Create card in Backlog |
| `issues.assigned` | Move to Todo |
| `issues.closed` (completed) | Move to Done |
| `issues.closed` (not_planned) | Move to Cancelled |
| `issues.reopened` | Move to Todo |
| `pull_request.opened` | Move linked issue's card to In Review |
| `pull_request.closed` + merged | Move to Done |

## Test plan
- [ ] `npm run typecheck` passes ✅
- [ ] HMAC verification rejects bad signatures
- [ ] Agent-owned cards queue events rather than move

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)