### PR TITLE
feat: Card Matcher Strategy 3 — branch → open GitHub PR lookup

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -9,6 +9,16 @@ export interface GitHubIssue {
   labels: string[]
 }
 
+export interface GitHubPR {
+  number: number
+  title: string
+  body: string | null
+  url: string
+  head: { ref: string }
+  state: 'open' | 'closed'
+  merged: boolean
+}
+
 export interface GitHubComment {
   id: number
   body: string
@@ -118,6 +128,28 @@ export class GitHubClient {
     const raw = await this.request<Array<Record<string, unknown>>>('/issues?state=open&per_page=100')
     // Filter out pull requests (GitHub returns PRs in issues endpoint)
     return raw.filter(r => !r.pull_request).map(r => this.mapIssue(r))
+  }
+
+  /** Find an open PR for the given branch name. Returns null if none or on error. */
+  async findPRForBranch(branch: string): Promise<GitHubPR | null> {
+    try {
+      const raw = await this.request<Array<Record<string, unknown>>>(
+        `/pulls?state=open&head=${encodeURIComponent(this.repo.split('/')[0])}:${encodeURIComponent(branch)}&per_page=5`
+      )
+      if (!raw.length) return null
+      const pr = raw[0]
+      return {
+        number: pr.number as number,
+        title: pr.title as string,
+        body: (pr.body as string | null) ?? null,
+        url: pr.html_url as string,
+        head: { ref: (pr.head as Record<string, string>).ref },
+        state: pr.state as 'open' | 'closed',
+        merged: !!(pr.merged as boolean)
+      }
+    } catch {
+      return null
+    }
   }
 
   /** Parse 'Closes #NNN', 'Fixes #NNN', 'Resolves #NNN' from PR body */

--- a/src/matcher/index.ts
+++ b/src/matcher/index.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from 'fs'
 import { resolve, join } from 'path'
 import type { VKClient, VKIssue } from '../vk/client.js'
 import type { BridgeConfig } from '../config.js'
+import { GitHubClient } from '../github/client.js'
+import { getProjectConfig } from '../config.js'
 
 export interface SessionInput {
   project_path: string
@@ -13,6 +15,7 @@ export interface MatchResult {
   card: VKIssue
   created: boolean
   strategy: 'worktree_metadata' | 'branch_issue_number' | 'branch_pr' | 'fuzzy_title' | 'created_new'
+
 }
 
 /** Resolve project_path → VK project_id using config */
@@ -101,8 +104,32 @@ export class CardMatcher {
       if (card) return { card, created: false, strategy: 'branch_issue_number' }
     }
 
-    // Strategy 3: Branch → GitHub PR (skip if no github config)
-    // (full implementation in Phase 2 GitHub bridge)
+    // Strategy 3: Branch → GitHub PR (only if project has GitHub config)
+    if (!ghNumber) {
+      const projConfig = getProjectConfig(session.project_path, this.config)
+      if (projConfig?.github_repo && projConfig?.github_token) {
+        const gh = new GitHubClient(projConfig.github_repo, projConfig.github_token)
+        const pr = await gh.findPRForBranch(session.branch).catch(() => null)
+        if (pr) {
+          // Try to find VK card via linked issue in PR body
+          const linkedNum = GitHubClient.extractLinkedIssue(pr.body)
+          if (linkedNum) {
+            const card = await this.vk.findIssueByGHNumber(projectId, linkedNum)
+            if (card) return { card, created: false, strategy: 'branch_pr' }
+          }
+          // PR exists but no linked issue — create card from PR title
+          const card = await this.vk.createIssue({
+            project_id: projectId,
+            status_id: statuses.in_progress,
+            title: pr.title,
+            description: `From PR #${pr.number}: ${pr.url}\n\n${pr.body ?? ''}`.trim(),
+            priority: priorityFromBranch(session.branch),
+            sort_order: Date.now() / 1e10
+          })
+          return { card, created: true, strategy: 'branch_pr' }
+        }
+      }
+    }
 
     // Strategy 4: Fuzzy title match
     const fuzzy = fuzzyMatch(session.branch, cards)


### PR DESCRIPTION
## Summary
- `GitHubClient.findPRForBranch(branch)` — queries GitHub pulls API for open PRs on the branch; returns null on miss or any error (non-fatal)
- `CardMatcher` Strategy 3 now fully implemented: checks for open PR when branch has no issue number, extracts linked issue via `Closes/Fixes/Resolves #NNN`, creates card from PR title as fallback
- Errors fall through silently to Strategy 4 (fuzzy match)

## Strategy chain (complete)
1. VK worktree metadata — `.vk-session.json` (exact, no guessing)
2. Branch issue number — `fix/issue-309` → `#309`
3. **Branch → open PR** — PR body `Closes #NNN` → find card; or create from PR title ← this PR
4. Fuzzy title match — `fix/auth-timeout` → "Fix auth timeout"
5. Create new card

## Test plan
- [ ] `npm run typecheck` passes ✅
- [ ] Branch with open PR + linked issue → finds existing VK card
- [ ] Branch with open PR + no linked issue → creates card from PR title
- [ ] Branch with no PR + no issue number → falls through to fuzzy match

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)