### PR TITLE
feat: Gemini wrapper + Zora middleware — Phase 4 adapters

### DIFF
--- a/hooks/gemini-wrapper.sh
+++ b/hooks/gemini-wrapper.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# vk-bridge Gemini wrapper
+# Registers the Gemini session with vk-bridge on start and marks it done on exit.
+# Add to ~/.zshrc:
+#   source ~/.vk-bridge/hooks/gemini-wrapper.sh
+
+BRIDGE_URL="${VK_BRIDGE_URL:-http://localhost:3334}"
+
+gemini() {
+  local PROJECT_PATH BRANCH SESSION_ID EXIT_CODE
+
+  PROJECT_PATH="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+  BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")"
+
+  # Register session — capture session_id, ignore errors if bridge is down
+  SESSION_ID="$(curl -sf -X POST "${BRIDGE_URL}/sessions" \
+    -H "Content-Type: application/json" \
+    -d "{\"runtime\":\"gemini\",\"project_path\":\"${PROJECT_PATH}\",\"branch\":\"${BRANCH}\"}" \
+    2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('session_id',''))" 2>/dev/null || true)"
+
+  # Run Gemini
+  command gemini "$@"
+  EXIT_CODE=$?
+
+  # Update status on exit
+  if [ -n "$SESSION_ID" ]; then
+    local STATUS="done"
+    [ $EXIT_CODE -ne 0 ] && STATUS="blocked"
+    curl -sf -X PATCH "${BRIDGE_URL}/sessions/${SESSION_ID}" \
+      -H "Content-Type: application/json" \
+      -d "{\"status\":\"${STATUS}\"}" > /dev/null 2>&1 || true
+  fi
+
+  return $EXIT_CODE
+}

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -64,3 +64,24 @@ with open(settings_path, "w") as f:
 
 print("✓ Hooks installed into", settings_path)
 PYEOF
+
+# Offer Gemini wrapper install
+echo ""
+echo "Gemini CLI wrapper (optional):"
+echo "  To track Gemini sessions, add this to your ~/.zshrc:"
+echo "    source $HOOKS_DIR/gemini-wrapper.sh"
+echo ""
+ZSHRC="${HOME}/.zshrc"
+if [ -f "$ZSHRC" ]; then
+  if grep -q "gemini-wrapper.sh" "$ZSHRC"; then
+    echo "  ✓ Gemini wrapper already in $ZSHRC"
+  else
+    read -r -p "  Add Gemini wrapper to $ZSHRC now? [y/N] " REPLY
+    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+      echo "" >> "$ZSHRC"
+      echo "# vk-bridge Gemini wrapper" >> "$ZSHRC"
+      echo "source $HOOKS_DIR/gemini-wrapper.sh" >> "$ZSHRC"
+      echo "  ✓ Added to $ZSHRC (restart your shell or run: source ~/.zshrc)"
+    fi
+  fi
+fi

--- a/src/zora/middleware.ts
+++ b/src/zora/middleware.ts
@@ -1,0 +1,81 @@
+/**
+ * vk-bridge Zora middleware
+ *
+ * Wraps a Zora task handler to auto-register sessions with vk-bridge.
+ * Non-blocking: if the bridge is down, the task runs normally.
+ *
+ * Usage:
+ *   import { withVKBridge } from '../path/to/vk-bridge/src/zora/middleware.js'
+ *
+ *   export const handler = withVKBridge(async (task, ctx) => {
+ *     // your task logic
+ *   })
+ */
+
+const BRIDGE_URL = process.env.VK_BRIDGE_URL ?? 'http://localhost:3334'
+
+export interface ZoraTask {
+  id?: string
+  projectPath?: string
+  branch?: string
+  [key: string]: unknown
+}
+
+export interface ZoraContext {
+  [key: string]: unknown
+}
+
+export type ZoraHandler<T extends ZoraTask = ZoraTask, C extends ZoraContext = ZoraContext> =
+  (task: T, ctx: C) => Promise<void>
+
+async function registerSession(task: ZoraTask): Promise<string | null> {
+  try {
+    const res = await fetch(`${BRIDGE_URL}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        runtime: 'zora',
+        project_path: task.projectPath ?? process.cwd(),
+        branch: task.branch ?? 'main'
+      }),
+      signal: AbortSignal.timeout(3000)
+    })
+    if (!res.ok) return null
+    const data = await res.json() as { session_id?: string }
+    return data.session_id ?? null
+  } catch {
+    return null
+  }
+}
+
+async function updateSession(
+  sessionId: string,
+  status: 'done' | 'blocked'
+): Promise<void> {
+  try {
+    await fetch(`${BRIDGE_URL}/sessions/${sessionId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+      signal: AbortSignal.timeout(3000)
+    })
+  } catch {
+    // ignore — bridge may have gone down
+  }
+}
+
+export function withVKBridge<T extends ZoraTask, C extends ZoraContext>(
+  handler: ZoraHandler<T, C>
+): ZoraHandler<T, C> {
+  return async (task: T, ctx: C): Promise<void> => {
+    const sessionId = await registerSession(task)
+
+    try {
+      await handler(task, ctx)
+      if (sessionId) await updateSession(sessionId, 'done')
+    } catch (err) {
+      if (sessionId) await updateSession(sessionId, 'blocked')
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
## Summary

### Gemini CLI wrapper (#24)
- `hooks/gemini-wrapper.sh` — bash function that wraps the `gemini` CLI
- Registers session with `runtime=gemini` on start, patches `done`/`blocked` on exit
- Uses curl only, no Node.js dependency
- `hooks/install.sh` now offers interactive `.zshrc` install at the end of hook setup (idempotent)

**Usage:**
```bash
# One-time setup (or npm run install-hooks then answer Y)
echo "source ~/.vk-bridge/hooks/gemini-wrapper.sh" >> ~/.zshrc
source ~/.zshrc

# Now every gemini session auto-registers
gemini "fix the auth bug"
```

### Zora task middleware (#25)
- `src/zora/middleware.ts` — `withVKBridge()` HOF wraps any Zora task handler
- 3-second timeout on all bridge calls; errors are fully isolated — bridge down never breaks task execution
- On success: `status=done`; on throw: `status=blocked` (then re-throws)

**Usage:**
```ts
import { withVKBridge } from 'vk-bridge/src/zora/middleware.js'

export const handler = withVKBridge(async (task, ctx) => {
  // your task logic here
})
```

## Test plan
- [ ] `npm run typecheck` passes ✅
- [ ] Gemini wrapper registers session when bridge is running
- [ ] Gemini wrapper exits cleanly when bridge is down
- [ ] Zora middleware marks done/blocked correctly
- [ ] Zora middleware re-throws original error

Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)